### PR TITLE
Quality-of-Life improvements

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -19,7 +19,7 @@
 #
 locals {
   network = var.network == "" ? google_compute_network.vault-network[0].self_link : var.network
-  subnet = var.subnet == "" ? google_compute_subnetwork.vault-subnet[0].self_link : var.subnet
+  subnet  = var.subnet == "" ? google_compute_subnetwork.vault-subnet[0].self_link : var.subnet
 }
 
 # Address for NATing
@@ -67,7 +67,7 @@ resource "google_compute_router_nat" "vault-nat" {
 }
 
 resource "google_compute_network" "vault-network" {
-  count = var.network == "" ? 1 : 0
+  count   = var.network == "" ? 1 : 0
   project = var.project_id
 
   name                    = "vault-network"
@@ -77,7 +77,7 @@ resource "google_compute_network" "vault-network" {
 }
 
 resource "google_compute_subnetwork" "vault-subnet" {
-  count = var.subnet == "" ? 1 : 0
+  count   = var.subnet == "" ? 1 : 0
   project = var.project_id
 
   name                     = "vault-subnet"

--- a/outputs.tf
+++ b/outputs.tf
@@ -86,16 +86,16 @@ EOF
 }
 
 output "vault_network" {
-  value = local.network
+  value       = local.network
   description = "The network in which the Vault cluster resides"
 }
 
 output "vault_subnet" {
-  value = local.subnet
+  value       = local.subnet
   description = "The subnetwork in which the Vault cluster resides"
 }
 
 output "vault_nat_ips" {
-  value = google_compute_address.vault-nat.*.address
+  value       = google_compute_address.vault-nat.*.address
   description = "The NAT-ips that the vault nodes will use to communicate with external services."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -250,14 +250,14 @@ EOF
 # --------------------
 
 variable "network" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "The self link of the VPC network for Vault. By default, one will be created for you."
 }
 
 variable "subnet" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "The self link of the VPC subnetwork for Vault. By default, one will be created for you."
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 
   required_providers {
     google = "~> 3.4"


### PR DESCRIPTION
I ran `terraform fmt` on the whole code. All terraform plans should conform to the same style guidelines.

In terraform 0.12.6, a new feature allows for `for_each` to replace the awkward `count/element` idiom for iterating on a list to generate resources. This feature has been implemented where appropriate.